### PR TITLE
chore: Handle Express SDK initialization errors

### DIFF
--- a/web-src/src/components/FavoriteVariantCard.js
+++ b/web-src/src/components/FavoriteVariantCard.js
@@ -59,7 +59,7 @@ export function FavoriteVariantCard({ variant, ...props }) {
       addImageToVariant(variant.id, publishParams.asset[0].data);
     };
 
-    await expressSDKService.handleImageOperation(
+    const success = await expressSDKService.handleImageOperation(
       'generateImage',
       {
         outputParams: {
@@ -73,6 +73,10 @@ export function FavoriteVariantCard({ variant, ...props }) {
         },
       },
     );
+
+    if (!success) {
+      ToastQueue.negative('Something went wrong. Please try again!', { timeout: 2000 });
+    }
   }, [expressSDKService, variant]);
 
   const handleGenerateImagePrompt = useCallback(() => {
@@ -106,7 +110,7 @@ export function FavoriteVariantCard({ variant, ...props }) {
                   log('prompt:copyfavorite');
                   sampleRUM('genai:prompt:copyfavorite', { source: 'FavoriteCard#onPress' });
                   navigator.clipboard.writeText(toText(variant.content));
-                  ToastQueue.positive('Copied to clipboard', { timeout: 1000 });
+                  ToastQueue.positive('Copied text to clipboard', { timeout: 1000 });
                 }}>
                 <CopyOutlineIcon />
               </ActionButton>

--- a/web-src/src/components/PromptResultCard.js
+++ b/web-src/src/components/PromptResultCard.js
@@ -199,7 +199,7 @@ export function PromptResultCard({ result, ...props }) {
       addImageToVariant(variantId, publishParams.asset[0].data);
     };
 
-    await expressSDKService.handleImageOperation(
+    const success = await expressSDKService.handleImageOperation(
       'generateImage',
       {
         outputParams: {
@@ -213,6 +213,10 @@ export function PromptResultCard({ result, ...props }) {
         },
       },
     );
+
+    if (!success) {
+      ToastQueue.negative('Something went wrong. Please try again!', { timeout: 2000 });
+    }
   }, [expressSDKService]);
 
   const handleGenerateImagePrompt = useCallback((variantId) => {

--- a/web-src/src/components/VariantImagesView.js
+++ b/web-src/src/components/VariantImagesView.js
@@ -90,7 +90,7 @@ export function VariantImagesView({ variant, isFavorite, ...props }) {
     };
     const assetData = variantImages[variant.id][index];
 
-    await expressSDKService.handleImageOperation(
+    const success = await expressSDKService.handleImageOperation(
       'editImage',
       {
         outputParams: {
@@ -108,6 +108,10 @@ export function VariantImagesView({ variant, isFavorite, ...props }) {
         },
       },
     );
+
+    if (!success) {
+      ToastQueue.negative('Something went wrong. Please try again!', { timeout: 2000 });
+    }
   }, [expressSDKService, variantImages]);
 
   const handleImageViewerOpen = useCallback((index) => {

--- a/web-src/src/services/ExpressSDKService.js
+++ b/web-src/src/services/ExpressSDKService.js
@@ -77,7 +77,7 @@ export class ExpressSDKService {
           this.ccEverywhereInstance = ccEverywhereInstance;
         })
         .catch((error) => {
-          console.error('Failed to initialize Express Editor:', error);
+          console.error('Error:', error);
           return false;
         });
     }

--- a/web-src/src/services/ExpressSDKService.js
+++ b/web-src/src/services/ExpressSDKService.js
@@ -72,7 +72,14 @@ export class ExpressSDKService {
 
   async handleImageOperation(operation, operationParams) {
     if (this.ccEverywhereInstance == null) {
-      this.ccEverywhereInstance = await this.initExpressEditor();
+      await this.initExpressEditor()
+        .then((ccEverywhereInstance) => {
+          this.ccEverywhereInstance = ccEverywhereInstance;
+        })
+        .catch((error) => {
+          console.error('Failed to initialize Express Editor:', error);
+          return false;
+        });
     }
 
     if (operation === 'generateImage') {
@@ -80,5 +87,6 @@ export class ExpressSDKService {
     } else if (operation === 'editImage') {
       this.ccEverywhereInstance.miniEditor.editImage(operationParams, this.userInfo, this.authInfo);
     }
+    return true;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Demo URL: https://experience.adobe.com/?shell_source=dev&ref=genai-plugin-dev&repo=wknd&owner=hlxsites&project=WKND#/@sitesinternal/aem/generate-variations/

## Description
- Handling of edge cases when Express SDK fails to initialize.
- A friendly toast message will be shown to encourage users to retry the image operation.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
