### PR TITLE
fix: included chevron icon in clickable area

### DIFF
--- a/web-src/src/components/FavoriteVariantListPanel.js
+++ b/web-src/src/components/FavoriteVariantListPanel.js
@@ -25,6 +25,7 @@ import ChevronLeft from '../assets/chevron-left.svg';
 
 const styles = {
   breadcrumbsLink: css`
+    display: flex;
     color: var(--alias-content-neutral-subdued-default, var(--alias-content-neutral-subdued-default, #464646));
     font-size: 16px;
     font-style: normal;
@@ -41,8 +42,10 @@ export function FavoriteVariantListPanel(props) {
   return (
     <>
       <Flex UNSAFE_style={{ padding: '20px 20px 20px' }} direction={'row'} justifyContent={'left'} alignItems={'center'} gridArea={'breadcrumbs'}>
-        <Image src={ChevronLeft} alt={'Back'} width={'24px'} />
-        <Link href="#" onPress={() => setViewType(ViewType.NewSession)} UNSAFE_className={styles.breadcrumbsLink}>{formatMessage(intlMessages.favoritesView.navigationLabel)}</Link>
+        <Link href="#" onPress={() => setViewType(ViewType.NewSession)} UNSAFE_className={styles.breadcrumbsLink}>
+          <Image src={ChevronLeft} alt={'Back'} width={'24px'} />
+          {formatMessage(intlMessages.favoritesView.navigationLabel)}
+        </Link>
       </Flex>
       <View
         paddingStart={'size-400'}

--- a/web-src/src/components/PromptSessionSideView.js
+++ b/web-src/src/components/PromptSessionSideView.js
@@ -35,6 +35,7 @@ const styles = {
     border-right: 2px solid rgb(224, 224, 224); 
   `,
   breadcrumbsLink: css`
+    display: flex;
     color: var(--alias-content-neutral-subdued-default, var(--alias-content-neutral-subdued-default, #464646));
     font-size: 16px;
     font-style: normal;
@@ -75,8 +76,10 @@ export function PromptSessionSideView({ isOpenPromptEditor, onTogglePrompt, ...p
       gap={'size-100'}>
 
       <Flex UNSAFE_className={styles.promptFlexItems} UNSAFE_style={{ paddingTop: '0', paddingBottom: '0' }} direction={'row'} justifyContent={'left'} alignItems={'center'} gridArea={'breadcrumbs'}>
+      <Link href="#" onPress={() => setViewType(ViewType.NewSession)} UNSAFE_className={styles.breadcrumbsLink}>
         <Image src={ChevronLeft} alt={'Back'} width={'24px'} />
-        <Link href="#" onPress={() => setViewType(ViewType.NewSession)} UNSAFE_className={styles.breadcrumbsLink}>{formatMessage(intlMessages.promptSessionSideView.navigationLabel)}</Link>
+        {formatMessage(intlMessages.promptSessionSideView.navigationLabel)}
+      </Link>
       </Flex>
 
       {currentSession


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Chevron icon in Prompt Templates breadcrumb is now clickable along with the link text

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/SITES-20479

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Some users tend to click on the chevron icon when trying to go back to the prompt templates page, which was initially not clickable.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
