### PR TITLE
Fix for retrieving ETag

### DIFF
--- a/actions/AemClient.js
+++ b/actions/AemClient.js
@@ -75,10 +75,10 @@ class AemClient {
       // For some reason (most likely an issue with the fragment variation creation API),
       // the returned ETag is not always correct. It's better to directly retrieve the created variation
       // and get the ETag from there. Additionally, I found that the created variation might not be instantly
-      // available after creation, so I added 1.5 seconds wait time.
+      // available after creation, so I added 2.5 seconds wait time.
       logger.debug(`Getting ETag for ${updateVariationUrl}`);
-      await wait(1.5);
-      const refreshed = await wretch(updateVariationUrl)
+      await wait(2.5);
+      const refreshed = await wretch(updateVariationUrl, { shouldRetry: true })
         .headers({
           'X-Adobe-Accept-Unsupported-API': '1',
           Authorization: `Bearer ${this.accessToken}`,

--- a/actions/AemClient.js
+++ b/actions/AemClient.js
@@ -75,7 +75,7 @@ class AemClient {
       // For some reason (most likely an issue with the fragment variation creation API),
       // the returned ETag is not always correct. It's better to directly retrieve the created variation
       // and get the ETag from there. Additionally, I found that the created variation might not be instantly
-      // available after creation, so I added some wait time.
+      // available after creation, so I added 1.5 seconds wait time.
       logger.debug(`Getting ETag for ${updateVariationUrl}`);
       await wait(1.5);
       const refreshed = await wretch(updateVariationUrl)

--- a/actions/AemClient.js
+++ b/actions/AemClient.js
@@ -75,9 +75,9 @@ class AemClient {
       // For some reason (most likely an issue with the fragment variation creation API),
       // the returned ETag is not always correct. It's better to directly retrieve the created variation
       // and get the ETag from there. Additionally, I found that the created variation might not be instantly
-      // available after creation, so I added 2.5 seconds wait time.
+      // available after creation, so I added 1.5 seconds wait time.
       logger.debug(`Getting ETag for ${updateVariationUrl}`);
-      await wait(2.5);
+      await wait(1.5);
       const refreshed = await wretch(updateVariationUrl, { shouldRetry: true })
         .headers({
           'X-Adobe-Accept-Unsupported-API': '1',

--- a/actions/AemClient.test.js
+++ b/actions/AemClient.test.js
@@ -87,6 +87,10 @@ describe('AemClient', () => {
       res: () => mockResPromise,
     }));
 
+    const mockGet = jest.fn(() => ({
+      res: () => mockResPromise,
+    }));
+
     const mockPatch = jest.fn(() => ({
       res: () => mockResPromise,
     }));
@@ -94,6 +98,7 @@ describe('AemClient', () => {
     wretch.mockReturnValue({
       headers: jest.fn().mockReturnThis(),
       post: mockPost,
+      get: mockGet,
       patch: mockPatch,
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For some reason (most likely an issue with the fragment variation creation API), the returned ETag is not always correct. It's better to directly retrieve the created variation and get the ETag from there. Additionally, I found that the created variation might not be instantly available after creation, so I added 1.5 seconds wait time.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/SITES-22574

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
https://experience-qa.adobe.com/?devMode=true&shell_source=workspace&workspace=debuge1275950&shell_ims=prod&aemHost=author-p7452-e12437.adobeaemcloud.com&fragmentId=145d7832-8adc-47b7-b58d-778dc067861c#/@sitesinternal/aem/generate-variations/

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
