### PR TITLE
feat: Switch to Access Profile API for checking Express entitlement

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,7 +16,7 @@ IMS_SERVICE_CLIENT_SECRET=
 IMS_SERVICE_PERM_AUTH_CODE=
 
 ## Express environment variables
-EXPRESS_PRODUCT_CONTEXT=spark
+EXPRESS_ENTITLEMENT=spark
 EXPRESS_SDK_URL=https://cc-embed.adobe.com/sdk/1p/v4/CCEverywhere.js
 
 # Target integration

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -29,7 +29,9 @@ jobs:
           IMS_SERVICE_CLIENT_SECRET: ${{ secrets.IMS_SERVICE_CLIENT_SECRET }}
           IMS_SERVICE_PERM_AUTH_CODE: ${{ secrets.IMS_SERVICE_PERM_AUTH_CODE }}
           IMS_PRODUCT_CONTEXT: dma_aem_cloud
-          EXPRESS_PRODUCT_CONTEXT: spark
+          EXPRESS_ENTITLEMENT: spark
+          ACCESS_PLATFORM_APP_ID: AemGenerateVariations1
+          ACCESS_PROFILE_ENDPOINT: 'https://aps-web.adobe.io'
           EXPRESS_SDK_URL: https://cc-embed.adobe.com/sdk/1p/v4/CCEverywhere.js
           SPLUNK_HEC__HEC_TOKEN: ${{ secrets.SPLUNK_HEC__HEC_TOKEN }}
           AIO_LOG_LEVEL: info

--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -31,7 +31,9 @@ jobs:
           IMS_SERVICE_CLIENT_SECRET: ${{ secrets.IMS_SERVICE_CLIENT_SECRET }}
           IMS_SERVICE_PERM_AUTH_CODE: ${{ secrets.IMS_SERVICE_PERM_AUTH_CODE }}
           IMS_PRODUCT_CONTEXT: dma_aem_cloud
-          EXPRESS_PRODUCT_CONTEXT: spark
+          EXPRESS_ENTITLEMENT: spark
+          ACCESS_PLATFORM_APP_ID: AemGenerateVariations1
+          ACCESS_PROFILE_ENDPOINT: 'https://aps-web.adobe.io'
           EXPRESS_SDK_URL: https://cc-embed.adobe.com/sdk/1p/v4/CCEverywhere.js
           SPLUNK_HEC__HEC_TOKEN: ${{ secrets.SPLUNK_HEC__HEC_TOKEN }}
           AIO_LOG_LEVEL: info

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In addition, the following values need to be manually set (request from a teamma
 - `IMS_SERVICE_CLIENT_SECRET`
 - `IMS_SERVICE_PERM_AUTH_CODE`
 - `SPLUNK_HEC__HEC_TOKEN`
-- `EXPRESS_PRODUCT_CONTEXT`
+- `EXPRESS_ENTITLEMENT`
 - `EXPRESS_SDK_URL`
 - `TARGET_API_KEY`
 - `FT_EARLY_ACCESS`

--- a/web-src/src/services/AccessProfileService.js
+++ b/web-src/src/services/AccessProfileService.js
@@ -11,7 +11,6 @@
  */
 
 import { wretch } from '../helpers/NetworkHelper.js';
-// import mockAccessProfile from '../../../data/mock-access-profile.json';
 
 export class AccessProfileService {
   constructor({
@@ -46,14 +45,6 @@ export class AccessProfileService {
 
     return JSON.parse(atob(response.asnp.payload));
   }
-
-  // static getMockAccessProfile() {
-  //   return new Promise((resolve) => {
-  //     setTimeout(() => {
-  //       resolve(mockAccessProfile);
-  //     }, 2000);
-  //   });
-  // }
 
   static create(imsToken) {
     if (!imsToken) {

--- a/web-src/src/services/AccessProfileService.js
+++ b/web-src/src/services/AccessProfileService.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { wretch } from '../helpers/NetworkHelper.js';
+// import mockAccessProfile from '../../../data/mock-access-profile.json';
+
+export class AccessProfileService {
+  constructor({
+    appId, clientId, endpoint, accessToken,
+  }) {
+    this.appId = appId;
+    this.clientId = clientId;
+    this.endpoint = endpoint;
+    this.accessToken = accessToken;
+  }
+
+  async getAccessProfile() {
+    const response = await wretch(`${this.endpoint}/webapps/access_profile/v3`)
+      .headers({
+        Authorization: `Bearer ${this.accessToken}`,
+        'x-api-key': this.clientId,
+      })
+      .post({
+        appDetails:
+        {
+          nglAppVersion: '1.0',
+          nglLibRuntimeMode: 'NAMED_USER_ONLINE',
+          nglLibVersion: '12.3',
+          locale: 'en_US',
+          appNameForLocale: this.appId,
+          nglAppId: this.appId,
+          appVersionForLocale: '1.0',
+        },
+        deviceDetails: {},
+      })
+      .json();
+
+    return JSON.parse(atob(response.asnp.payload));
+  }
+
+  // static getMockAccessProfile() {
+  //   return new Promise((resolve) => {
+  //     setTimeout(() => {
+  //       resolve(mockAccessProfile);
+  //     }, 2000);
+  //   });
+  // }
+
+  static create(imsToken) {
+    if (!imsToken) {
+      return null;
+    }
+    return new AccessProfileService({
+      appId: process.env.ACCESS_PLATFORM_APP_ID,
+      clientId: process.env.IMS_CLIENT_ID,
+      endpoint: process.env.ACCESS_PROFILE_ENDPOINT,
+      accessToken: imsToken,
+    });
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/SITES-20576
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
https://experience-qa.adobe.com/?devMode=true&shell_source=dev&shell_ims=prod#/@sitesinternal/aem/generate-variations/
<!--- Please describe in detail how you tested your changes. -->
The `Generate Image` button should be enabled in "Adobe Inc." and "Sites Internal" IMS org and usually disabled in other IMS orgs.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
