### PR TITLE
[SITES-22179] fix: use localized string for Help icon in MainSidePanel

### DIFF
--- a/web-src/src/components/IntlProviderWrapper.js
+++ b/web-src/src/components/IntlProviderWrapper.js
@@ -20,6 +20,7 @@ import * as messagesPromptSessionSideView from './__localization__/PromptSession
 import * as messagesFavorites from './__localization__/Favorites.l10n';
 import * as messagesImageViewer from './__localization__/ImageViewer.l10n';
 import * as messagesContentFragmentExportButton from './__localization__/ContentFragmentExportButton.l10n';
+import * as messagesAdditionalContextInput from './__localization__/AdditionalContextInput.l10n';
 import * as messagesPromptTemplateCard from './__localization__/PromptTemplateCard.l10n';
 import { useShellContext } from './ShellProvider';
 /* eslint-enable import/extensions */
@@ -38,6 +39,7 @@ function getAllMessages(locale) {
     ...messagesFavorites[normalizedLocale],
     ...messagesImageViewer[normalizedLocale],
     ...messagesContentFragmentExportButton[normalizedLocale],
+    ...messagesAdditionalContextInput[normalizedLocale],
     ...messagesPromptTemplateCard[normalizedLocale],
   };
 }

--- a/web-src/src/components/MainSidePanel.js
+++ b/web-src/src/components/MainSidePanel.js
@@ -240,7 +240,7 @@ export function MainSidePanel(props) {
       <Flex direction={'column'} gridArea={'footer'} gap={'16px'}>
         <div className={style.menu}>
           <div className={style.menuItem}>
-            <ClickableImage src={HelpIcon} width={'20px'} title={formatMessage(intlMessages.mainSidePanel.helpAndFaqsMenuItem)} alt={'Help'} onClick={() => window.open(formatMessage(intlMessages.mainSidePanel.helpUrl), '_blank')} />
+            <ClickableImage src={HelpIcon} width={'20px'} title={formatMessage(intlMessages.mainSidePanel.helpAndFaqsMenuItem)} alt={formatMessage(intlMessages.mainSidePanel.helpAndFaqsAltText)} onClick={() => window.open(formatMessage(intlMessages.mainSidePanel.helpUrl), '_blank')} />
             {mainSidePanelType === MainSidePanelType.Expanded && <Link href={formatMessage(intlMessages.mainSidePanel.helpUrl)} target="_blank" UNSAFE_className={style.menu}>{formatMessage(intlMessages.mainSidePanel.helpAndFaqsMenuItem)}</Link>}
           </div>
           <div className={style.menuItem}>


### PR DESCRIPTION
# Use localized alt text for Help icon

## Description

Updated the Help icon to use the existing localized `mainSidePanel.helpAndFaqsAltText` string instead of the hardcoded 'Help' string. This change completes the localization work started in PR #315 (https://github.com/adobe/aem-genai-assistant/pull/315) where the localized string was created but not fully applied to the UI component.

## Related Issue

SITES-22179: Hardcoded 'Help' string in Generate Variations

## Motivation and Context

Ensures consistent localization across the application by using the existing translated strings for all UI elements, improving accessibility and internationalization support.

## How Has This Been Tested?

Locally verified that the alt text for the Help icon now correctly uses the localized string from the translation files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.