### PR TITLE
fix: Invalid Date formatting across Generate Variations

### DIFF
--- a/web-src/src/components/MainSidePanel.js
+++ b/web-src/src/components/MainSidePanel.js
@@ -33,7 +33,7 @@ import { sessionState } from '../state/SessionState.js';
 import { ViewType, viewTypeState } from '../state/ViewType.js';
 import { MainSidePanelType, mainSidePanelTypeState } from '../state/MainSidePanelTypeState.js';
 import { ClickableImage } from './ClickableImage.js';
-import { newGroupingLabelGenerator } from '../helpers/FormatHelper.js';
+import { newGroupingLabelGenerator, getSessionDate } from '../helpers/FormatHelper.js';
 import { useApplicationContext } from './ApplicationProvider.js';
 import { contentFragmentState } from '../state/ContentFragmentState.js';
 import { RUN_MODE_CF } from '../state/RunMode.js';
@@ -203,8 +203,13 @@ export function MainSidePanel(props) {
             </li>
             {(mainSidePanelType === MainSidePanelType.Expanded && sessions && sessions.length > 0)
               && sessions.toReversed().map((session) => {
-                const sessionDate = new Date(session.name);
-                const groupingLabel = groupingLabelGenerator(sessionDate);
+                const sessionDate = getSessionDate(session);
+                const groupingLabel = groupingLabelGenerator(sessionDate ?? new Date(0));
+                const formattedDate = sessionDate
+                  ? sessionDate.toLocaleString(user.locale, {
+                    month: 'numeric', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric',
+                  })
+                  : '';
                 return (
                       <>
                         {groupingLabel
@@ -213,18 +218,10 @@ export function MainSidePanel(props) {
                               UNSAFE_className={style.subMenuHeader}>
                               {formatMessage(intlMessages.mainSidePanel[groupingLabel])}
                             </Text>}
-                        {/* eslint-disable-next-line max-len */}
                         <li className={currentSession && viewType === ViewType.CurrentSession && session && session.id === currentSession.id ? derivedStyles.clickedSubMenuItem : style.subMenuItem}
                             key={session.id}>
                           <Link href="#" UNSAFE_className={style.menuItemLink}
-                                onPress={() => handleRecent(session)}>{`${session.name.split(' ')[0]} ${sessionDate.toLocaleString(user.locale, {
-                                  month: 'numeric',
-                                  day: 'numeric',
-                                  year: 'numeric',
-                                  hour: 'numeric',
-                                  minute: 'numeric',
-                                  hour12: true,
-                                })}`}</Link>
+                                onPress={() => handleRecent(session)}>{`${session.name.split(' ')[0]} ${formattedDate}`.trim()}</Link>
                         </li>
                       </>
                 );

--- a/web-src/src/components/PromptResultCard.js
+++ b/web-src/src/components/PromptResultCard.js
@@ -230,7 +230,6 @@ export function PromptResultCard({ result, ...props }) {
     year: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-    hour12: true,
   });
 
   const reusePrompt = useCallback(() => {

--- a/web-src/src/components/PromptSessionSideView.js
+++ b/web-src/src/components/PromptSessionSideView.js
@@ -18,6 +18,7 @@ import { css } from '@emotion/css';
 import { useIntl } from 'react-intl';
 
 import { intlMessages } from './PromptSessionSideView.l10n.js';
+import { getSessionDate } from '../helpers/FormatHelper.js';
 import { PromptInputView } from './PromptInputView.js';
 import { GenerateButton } from './GenerateButton.js';
 
@@ -72,7 +73,10 @@ export function PromptSessionSideView({
 
   function getTemplateDate() {
     try {
-      const date = new Date(currentSession.name.split(' ').slice(-3).join(' '));
+      const date = getSessionDate(currentSession);
+      if (!date) {
+        return formatMessage(intlMessages.promptSessionSideView.empty);
+      }
       return Intl.DateTimeFormat(user.locale, { dateStyle: 'short', timeStyle: 'short' }).format(date);
     } catch (error) {
       return formatMessage(intlMessages.promptSessionSideView.empty);

--- a/web-src/src/components/SavePromptButton.js
+++ b/web-src/src/components/SavePromptButton.js
@@ -210,7 +210,6 @@ export function SavePromptButton(props) {
       year: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
-      hour12: true,
     });
 
     return (

--- a/web-src/src/helpers/FormatHelper.js
+++ b/web-src/src/helpers/FormatHelper.js
@@ -9,6 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+export function getSessionDate(session) {
+  const date = session.timestamp
+    ? new Date(session.timestamp)
+    : new Date((session.name ?? '').split(' ').slice(-3).join(' '));
+  return isNaN(date.getTime()) ? null : date;
+}
+
 export function formatTimestamp(timestamp) {
   const date = new Date(timestamp);
   const dateStr = date.toLocaleDateString('en-US');

--- a/web-src/src/helpers/FormatHelper.test.js
+++ b/web-src/src/helpers/FormatHelper.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import {
-  newGroupingLabelGenerator, formatIdentifier, extractL10nId, handleLocalizedResponse,
+  newGroupingLabelGenerator, formatIdentifier, extractL10nId, handleLocalizedResponse, getSessionDate,
 } from './FormatHelper.js';
 
 describe('newGroupingLabelGenerator', () => {
@@ -213,5 +213,42 @@ describe('handleLocalizedResponse', () => {
   it('should return the input message if the error code is undefined', () => {
     const input = undefined;
     expect(handleLocalizedResponse(input, 'An error occurred while generating results')).toEqual(input);
+  });
+});
+
+describe('getSessionDate', () => {
+  const KNOWN_TIMESTAMP = 1726056960000;
+
+  it('returns a Date equal to session.timestamp when timestamp is present', () => {
+    const session = { timestamp: KNOWN_TIMESTAMP, name: 'Template 9/11/2024 12:16 AM' };
+    const date = getSessionDate(session);
+    expect(date).toBeInstanceOf(Date);
+    expect(date.getTime()).toBe(KNOWN_TIMESTAMP);
+  });
+
+  it('does not return "Invalid Date" — result is a valid Date when timestamp is set', () => {
+    const session = { timestamp: KNOWN_TIMESTAMP, name: 'My Template 1/1/1970 12:00 AM' };
+    const date = getSessionDate(session);
+    expect(date).not.toBeNull();
+    expect(isNaN(date.getTime())).toBe(false);
+  });
+
+  it('falls back to name-parse and returns a valid Date when timestamp is absent', () => {
+    const ts = KNOWN_TIMESTAMP;
+    const enUsDateStr = new Date(ts).toLocaleDateString('en-US');
+    const enUsTimeStr = new Date(ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric' });
+    const session = { name: `My Template ${enUsDateStr} ${enUsTimeStr}` };
+    const date = getSessionDate(session);
+    expect(date).toBeInstanceOf(Date);
+    expect(isNaN(date.getTime())).toBe(false);
+  });
+
+  it('returns null when timestamp is absent and name cannot be parsed as a date', () => {
+    const session = { name: 'Unparseable session name' };
+    expect(getSessionDate(session)).toBeNull();
+  });
+
+  it('returns null when both timestamp and name are absent', () => {
+    expect(getSessionDate({})).toBeNull();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `getSessionDate(session)` that uses the numeric `session.timestamp` as the authoritative source, falls back to name-parse for legacy sessions, returns null for unresolvable inputs.
<!--- Describe your changes in detail -->

<img width="1904" height="795" alt="dates" src="https://github.com/user-attachments/assets/e90402aa-ceb0-42c2-aca1-a9c0f74489d2" />


## Related Issue
SITES-45014
SITES-25110
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
