### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aem-genai-assistant",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aem-genai-assistant",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@adobe/aio-sdk": "3.0.0",
         "@adobe/exc-app": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aem-genai-assistant",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
## Description

Bumps the app version `3.0.1` → `3.1.0` (minor).

The minor bump reflects the user-facing **AI (CAI) compliance notice** added to the Generate Variations prompt panel (SITES-46697, merged in #325), plus incoming localization updates.

## Changes
- `package.json`: version → `3.1.0`
- `package-lock.json`: root + package version fields → `3.1.0`

Version fields updated via `npm version 3.1.0 --no-git-tag-version` (no dependency changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)